### PR TITLE
generate cmake config modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,16 +30,44 @@ include_directories(
   ${MARISA_INCLUDE_DIRS}
 )
 
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
+configure_package_config_file(
+  marisa-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/marisa-config.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/marisa
+  PATH_VARS CMAKE_INSTALL_INCLUDEDIR
+)
+
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/marisa-version.cmake
+  COMPATIBILITY SameMajorVersion
+)
+
 add_library(marisa
     ${MARISA_SRC}
 )
 
 install(TARGETS marisa
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib)
+        EXPORT marisa-targets
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 set(include_headers ${MARISA_ROOT}/include/marisa.h)
 file(GLOB libmarisa_include_headers ${MARISA_ROOT}/include/marisa/*.h)
 install(FILES ${include_headers} DESTINATION include)
 install(FILES ${libmarisa_include_headers} DESTINATION include/marisa)
+
+install(
+  EXPORT marisa-targets
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/marisa
+)
+
+install(
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/marisa-config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/marisa-version.cmake
+  DESTINATION
+    ${CMAKE_INSTALL_LIBDIR}/cmake/marisa)

--- a/marisa-config.cmake.in
+++ b/marisa-config.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+include(${CMAKE_CURRENT_LIST_DIR}/marisa-targets.cmake)
+
+set_and_check(MARISA_INCLUDE_DIR @PACKAGE_CMAKE_INSTALL_INCLUDEDIR@/marisa)
+
+check_required_components(marisa)


### PR DESCRIPTION
If `lib/cmake/marisa-config.cmake` etc are available, no need to use `cmake/FindMarisa.cmake`, where `find_library` is called to set `Marisa_LIBRARY`, which is used in `target_link_libraries`.
Instead, simply call `target_link_libraries(... marisa)` as `marisa-targets` is exported.